### PR TITLE
Update auth.yaml

### DIFF
--- a/kubernetes/deployments/auth.yaml
+++ b/kubernetes/deployments/auth.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: auth
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: auth
   template:
     metadata:
       labels:


### PR DESCRIPTION
There was an error when I was doing a lab based on this file in Qwikilabs.

The error was :
error: unable to recognise “deployments/auth.yank”. no matches for kind “Deployment” in version “extensions/v1beta”

So I made changed in the apiVersion line
and then added 3 lines in the sec: after replicas 1
aiming at the proper selector.